### PR TITLE
Require Node 14, update dependencies, and fix tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,6 @@ jobs:
       matrix:
         node-version:
           - 14
-          - 12
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 18
+          - 16
           - 14
     steps:
       - uses: actions/checkout@v2

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export type HTMLAttributes = Record<string, string | number | boolean | readonly string[]>;
 
 /**

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	"type": "module",
 	"exports": "./index.js",
 	"engines": {
-		"node": ">=12"
+		"node": ">=14"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"

--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
 		"transform"
 	],
 	"dependencies": {
-		"escape-goat": "^3.0.0"
+		"escape-goat": "^4.0.0"
 	},
 	"devDependencies": {
-		"ava": "^3.15.0",
-		"tsd": "^0.14.0",
-		"xo": "^0.38.2"
+		"ava": "^5.2.0",
+		"tsd": "^0.28.1",
+		"xo": "^0.53.1"
 	}
 }

--- a/test.js
+++ b/test.js
@@ -9,26 +9,26 @@ test('stringifies attributes', t => {
 			number: 1,
 			multiple: [
 				'a',
-				'b'
+				'b',
 			],
-			alt: ''
+			alt: '',
 		}),
-		' unicorn="🦄" rainbow number="1" multiple="a b" alt=""'
+		' unicorn="🦄" rainbow number="1" multiple="a b" alt=""',
 	);
 });
 
 test('nothing', t => {
 	t.is(
 		stringifyAttributes({}),
-		''
+		'',
 	);
 });
 
 test('escapes attributes', t => {
 	t.is(
 		stringifyAttributes({
-			class: '<script></script>'
+			class: '<script></script>',
 		}),
-		' class="&lt;script&gt;&lt;/script&gt;"'
+		' class="&lt;script&gt;&lt;/script&gt;"',
 	);
 });


### PR DESCRIPTION
The test step for this package is currently broken because `tsd` is erroneously analyzing type definitions from dependencies. I was able to fix this by updating `tsd` to the newest version, however the Node 12 test step was then failing because of the use of optional chaining and nullish coalescing in updated sub-dependencies.

In this PR, I am requiring Node >=14 (Node 12 is now long unsupported anyway) and have updated all dependencies to their newest versions (which involved fixing new lint errors from the updated version of `xo`). All tests now correctly pass in Node 14, 16, and 18.