### PR TITLE
Omit `undefined` and `null` attributes

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ export default function stringifyAttributes(attributes) {
 	const handledAttributes = [];
 
 	for (let [key, value] of Object.entries(attributes)) {
-		if (value === false) {
+		if (value === false || value === undefined || value === null) {
 			continue;
 		}
 

--- a/test.js
+++ b/test.js
@@ -13,7 +13,7 @@ test('stringifies attributes', t => {
 			],
 			alt: '',
 			undef: undefined,
-			null: null
+			null: null,
 		}),
 		' unicorn="🦄" rainbow number="1" multiple="a b" alt=""'
 	);

--- a/test.js
+++ b/test.js
@@ -11,7 +11,9 @@ test('stringifies attributes', t => {
 				'a',
 				'b'
 			],
-			alt: ''
+			alt: '',
+			undef: undefined,
+			null: null
 		}),
 		' unicorn="🦄" rainbow number="1" multiple="a b" alt=""'
 	);


### PR DESCRIPTION
Currently, if the value of an attribute is `undefined` or `null`, the attribute will be awkwardly stringified:
```js
stringifyAttributes({
	undef: undefined,
	null: null
});
//=> ' undef="undefined" null="null"'
```

I don't think this is the desirable behavior; I think the desirable behavior would be for such attributes to simply be omitted, as is currently the case with attributes set to `false`. This PR makes this change.

The test step is currently failing unrelated to this PR. I have fixed this in #3. Since that PR updates the lint rules, and since the test step is currently broken anyway, I have written this PR to fit with the updated lint rules in #3.